### PR TITLE
Make diehard a singleton

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,18 @@
 
   var async = require('async'),
     debug = require('debug')('diehard'),
-    handlers = [];
+    assert = require('assert'),
+    handlers = [],
+    diehard = global.diehard;
+
+  if (!diehard) {
+    module.exports.version = require('./package.json').version;
+    diehard = global.diehard = module.exports;
+  } else {
+    assert(diehard.version === require('./package.json').version, 'Can only load one diehard');
+    module.exports = diehard;
+    return;
+  }
 
   module.exports.register = function (handler) {
     if (!handler) {


### PR DESCRIPTION
If multiple modules require diehard, we need to ensure there is only one diehard or calling listen will only call some of the handlers. [This method](https://github.com/npm/npm/issues/5080#issuecomment-40553859) has been suggested since `peerDependencies` have been deprecated.
